### PR TITLE
Fix inertia handling in emotional state updates

### DIFF
--- a/emotional_core/emotions.py
+++ b/emotional_core/emotions.py
@@ -46,9 +46,9 @@ class EmotionState:
         self.arousal = _clip(self.arousal, 0.0, 1.0)
 
     def apply_delta(self, dv: float, da: float, inertia: float = 0.75):
-        # Inertia: blend previous state to avoid jerk
-        self.valence = _clip(self.valence * inertia + dv * (1.0 - inertia), -1.0, 1.0)
-        self.arousal = _clip(self.arousal * inertia + da * (1.0 - inertia), 0.0, 1.0)
+        # Inertia: dampen change rather than averaging with absolute delta
+        self.valence = _clip(self.valence + dv * (1.0 - inertia), -1.0, 1.0)
+        self.arousal = _clip(self.arousal + da * (1.0 - inertia), 0.0, 1.0)
 
     def compute_discrete_emotion(self) -> str:
         # Choose the emotion whose center is closest in (v,a) Euclidean distance

--- a/tests/test_emotions.py
+++ b/tests/test_emotions.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the project root is on sys.path so emotional_core can be imported
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from emotional_core.emotions import EmotionState
+
+
+def test_apply_delta_respects_inertia():
+    st = EmotionState(valence=0.5, arousal=0.4)
+    st.apply_delta(dv=0.2, da=0.1, inertia=0.75)
+    assert st.valence == pytest.approx(0.5 + 0.2 * (1 - 0.75))
+    assert st.arousal == pytest.approx(0.4 + 0.1 * (1 - 0.75))


### PR DESCRIPTION
## Summary
- correct `apply_delta` to dampen valence/arousal changes instead of averaging with delta
- add regression test for inertia behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c5a443bc8324aae0ecb5fbfdd1fe