### PR TITLE
Enable continuous emotion processing

### DIFF
--- a/emotional_core/telemetry.py
+++ b/emotional_core/telemetry.py
@@ -4,10 +4,11 @@ from collections import deque
 
 try:  # pragma: no cover - graphical backend selection
     import matplotlib
-
     try:
+        # Only use the Tk backend when the tkinter module is available
+        import tkinter  # noqa: F401
         matplotlib.use("TkAgg")
-    except Exception:  # Fallback when Tk is unavailable (e.g. headless)
+    except Exception:
         matplotlib.use("Agg")
 
     import matplotlib.pyplot as plt
@@ -29,7 +30,13 @@ class EmotionPlotter:
         self.max_points = max_points
         self.valence_history = deque(maxlen=max_points)
         self.arousal_history = deque(maxlen=max_points)
-        self.fig, self.ax = plt.subplots()
+
+        try:
+            self.fig, self.ax = plt.subplots()
+        except Exception:
+            # Backend failed to initialize (e.g. missing Tk); disable plotting
+            self.enabled = False
+            return
         (self.valence_line,) = self.ax.plot([], [], label="valence")
         (self.arousal_line,) = self.ax.plot([], [], label="arousal")
         self.ax.set_xlabel("step")

--- a/emotional_core/telemetry.py
+++ b/emotional_core/telemetry.py
@@ -34,6 +34,8 @@ class EmotionPlotter:
         try:
             self.fig, self.ax = plt.subplots()
             plt.show(block=False)
+            # Give the GUI event loop a chance to create the window
+            plt.pause(0.001)
         except Exception:
             # Backend failed to initialize (e.g. missing Tk); disable plotting
             self.enabled = False
@@ -73,6 +75,8 @@ class EmotionPlotter:
         self.info_text.set_text("\n".join(f"{k}: {v}" for k, v in info.items()))
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
+        # Ensure the window remains responsive on some platforms
+        plt.pause(0.001)
 
     def close(self) -> None:
         if self.enabled:

--- a/emotional_core/telemetry.py
+++ b/emotional_core/telemetry.py
@@ -22,7 +22,7 @@ class EmotionPlotter:
     """Realtime plot of valence, arousal and discrete emotion."""
 
     def __init__(self, max_points: int = 100):
-        self.enabled = plt is not None
+        self.enabled = plt is not None and plt.get_backend().lower() != "agg"
         if not self.enabled:
             return
 
@@ -33,6 +33,7 @@ class EmotionPlotter:
 
         try:
             self.fig, self.ax = plt.subplots()
+            plt.show(block=False)
         except Exception:
             # Backend failed to initialize (e.g. missing Tk); disable plotting
             self.enabled = False

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-import time, os
-from dataclasses import dataclass
-from typing import Tuple
+
+import time
+import threading
+from queue import Empty, Queue
 
 from emotional_core.config import CONFIG
 from emotional_core.emotions import EmotionState
@@ -12,50 +13,67 @@ from emotional_core.brain import Brain, BrainConfig
 from emotional_core.telemetry import EmotionPlotter
 
 
-def emotional_update(state: EmotionState, user_text: str) -> EmotionState:
+def emotional_step(
+    state: EmotionState, dt: float, user_text: str | None = None
+) -> EmotionState:
+    """Advance the emotional state by ``dt`` seconds.
+
+    If ``user_text`` is provided, the appraisal of that text influences the
+    resulting state. The function always performs decay and discrete emotion
+    updates so it can be called on every loop iteration regardless of whether
+    new input has arrived.
+    """
+
     now = time.time()
-    # 1) decay
+    # 1) decay based on real time delta
     state.decay_toward_baseline(
-        dt=1.0,  # assume ~1s between steps in CLI; real apps: use real dt
+        dt=dt,
         valence_half_life=CONFIG.decay.valence_half_life,
         arousal_half_life=CONFIG.decay.arousal_half_life,
     )
-    # 2) appraisal
-    a = appraise(user_text)
-    # Scale deltas by input intensity so emphatic messages have bigger impact
-    intensity_factor = 1 + a.intensity
-    dv = a.sentiment * CONFIG.weights.sentiment_to_valence * intensity_factor
-    da = a.intensity * CONFIG.weights.intensity_to_arousal
-    # emotion-specific nudges (also scaled by intensity)
-    mult = intensity_factor
-    if a.discrete_hint == "anger":
-        dv -= 0.2 * mult
-        da += 0.15 * mult
-    elif a.discrete_hint == "sadness":
-        dv -= 0.25 * mult
-        da -= 0.05 * mult
-    elif a.discrete_hint == "fear":
-        dv -= 0.25 * mult
-        da += 0.05 * mult
-    elif a.discrete_hint == "disgust":
-        dv -= 0.2 * mult
-        da += 0.05 * mult
-    elif a.discrete_hint == "joy":
-        dv += 0.3 * mult
-        da += 0.05 * mult
-    elif a.discrete_hint == "surprise":
-        da += 0.2 * mult
-    elif a.discrete_hint == "curiosity":
-        da += 0.1 * mult
-    elif a.discrete_hint == "affection":
-        dv += 0.25 * mult
-        da -= 0.05 * mult
 
-    # 3) inertia-blended delta
-    state.apply_delta(dv, da, inertia=CONFIG.weights.inertia)
-    # 4) discrete selection with stickiness; high intensity or anger can force switch
-    force_switch = a.discrete_hint == "anger" or a.intensity > 0.7
-    state.maybe_switch_discrete(now, CONFIG.decay.min_emotion_duration, force=force_switch)
+    force_switch = False
+    if user_text is not None:
+        # 2) appraisal
+        a = appraise(user_text)
+        # Scale deltas by input intensity so emphatic messages have bigger impact
+        intensity_factor = 1 + a.intensity
+        dv = a.sentiment * CONFIG.weights.sentiment_to_valence * intensity_factor
+        da = a.intensity * CONFIG.weights.intensity_to_arousal
+        # emotion-specific nudges (also scaled by intensity)
+        mult = intensity_factor
+        if a.discrete_hint == "anger":
+            dv -= 0.2 * mult
+            da += 0.15 * mult
+        elif a.discrete_hint == "sadness":
+            dv -= 0.25 * mult
+            da -= 0.05 * mult
+        elif a.discrete_hint == "fear":
+            dv -= 0.25 * mult
+            da += 0.05 * mult
+        elif a.discrete_hint == "disgust":
+            dv -= 0.2 * mult
+            da += 0.05 * mult
+        elif a.discrete_hint == "joy":
+            dv += 0.3 * mult
+            da += 0.05 * mult
+        elif a.discrete_hint == "surprise":
+            da += 0.2 * mult
+        elif a.discrete_hint == "curiosity":
+            da += 0.1 * mult
+        elif a.discrete_hint == "affection":
+            dv += 0.25 * mult
+            da -= 0.05 * mult
+
+        # 3) inertia-blended delta
+        state.apply_delta(dv, da, inertia=CONFIG.weights.inertia)
+        # 4) high intensity or anger can force switch
+        force_switch = a.discrete_hint == "anger" or a.intensity > 0.7
+
+    # Discrete selection with stickiness
+    state.maybe_switch_discrete(
+        now, CONFIG.decay.min_emotion_duration, force=force_switch
+    )
     return state
 
 
@@ -73,42 +91,65 @@ def run_cli():
         )
     )
     plotter = EmotionPlotter()
-    try:
-        while True:
+
+    # Queue for incoming user messages read on a background thread
+    q: Queue[str] = Queue()
+    stop = False
+
+    def reader():
+        nonlocal stop
+        while not stop:
             try:
-                user = input("you> ").strip()
+                msg = input("you> ").strip()
             except (EOFError, KeyboardInterrupt):
-                print("\nbye!")
-                break
-            if user == "":
-                continue
-            if user.lower() in {":quit", ":q", "exit"}:
-                print("bot> take care!")
-                break
-            if user.lower() == ":state":
-                print("bot>", state.as_dict())
-                continue
+                stop = True
+                return
+            q.put(msg)
 
-            # Update emotion
-            state = emotional_update(state, user)
+    threading.Thread(target=reader, daemon=True).start()
+
+    last = time.time()
+    try:
+        while not stop:
+            now = time.time()
+            dt = now - last
+            last = now
+
+            # Consume a message if available
+            user = None
+            try:
+                user = q.get_nowait()
+            except Empty:
+                pass
+
+            if user:
+                if user.lower() in {":quit", ":q", "exit"}:
+                    print("bot> take care!")
+                    stop = True
+                elif user.lower() == ":state":
+                    state = emotional_step(state, dt)
+                    print("bot>", state.as_dict())
+                elif user != "":
+                    state = emotional_step(state, dt, user)
+                    mem.add("user", user)
+                    context = mem.recent_context(limit=6)
+                    raw = brain.generate_base(user, state.current_emotion, context)
+                    styled = shape(
+                        raw,
+                        state.current_emotion,
+                        state.arousal,
+                        base_max_tokens=CONFIG.behavior.base_max_tokens,
+                        emoji_baseline=CONFIG.behavior.emoji_baseline,
+                    )
+                    print("bot>", styled)
+                    mem.add("bot", styled)
+            else:
+                state = emotional_step(state, dt)
+
             plotter.update(state)
-
-            # Build context & generate base reply
-            mem.add("user", user)
-            context = mem.recent_context(limit=6)
-            raw = brain.generate_base(user, state.current_emotion, context)
-
-            # Style shaping
-            styled = shape(
-                raw,
-                state.current_emotion,
-                state.arousal,
-                base_max_tokens=CONFIG.behavior.base_max_tokens,
-                emoji_baseline=CONFIG.behavior.emoji_baseline,
-            )
-            print("bot>", styled)
-            mem.add("bot", styled)
+            time.sleep(0.1)
     finally:
+        stop = True
         plotter.close()
 
 


### PR DESCRIPTION
## Summary
- Add `emotional_step` for time-based state decay and optional appraisal
- Run CLI loop continuously with background input thread and telemetry updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d175380483248dbc86c006808c0e